### PR TITLE
Add secret hosting, switch to `network.target`, kubelet root directory fix, introduce `k3s-utils`, and clean up ERB code

### DIFF
--- a/jobs/k3s-agent/spec
+++ b/jobs/k3s-agent/spec
@@ -1,7 +1,9 @@
 ---
 name: k3s-agent
 
-packages: []
+packages:
+  - k3s-utils
+
 templates:
   config/bpm.yml: config/bpm.yml
   bin/pre-start.erb: bin/pre-start
@@ -128,6 +130,23 @@ properties:
   k3s.token-file-content:
     description: token-file content. see https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file
 
+  k3s.host-secrets.dir:
+    description: a directory of secrets to create
+    default: /var/vcap/data/secrets
+
+  k3s.host-secrets.files:
+    description: a list of secrets to create
+    default: []
+    example: |
+      - name: cloud.conf
+        content: |+
+          [Global]
+          auth-url=https://openstack.internal:5000/v3
+          domain-name=Default
+          region=RegionOne
+          tenant-id=badcafefeddeadbeeffacedeafbadcad
+          username=k3s-admin
+          password=**********
 # args
   k3s.kubelet-args:
     description: (agent/flags) Customized flag for kubelet process
@@ -156,7 +175,7 @@ properties:
       #   # default value
       #   #endpoint: localhost:4317
       #   samplingRatePerMillion: 100
-        
+
 
   k3s.containerd_additional_env_vars:
     description: additional env vars to set for containerd (the key will be prefixed with CONTAINERD_, and set in k3s launch context

--- a/jobs/k3s-agent/templates/bin/ctl.erb
+++ b/jobs/k3s-agent/templates/bin/ctl.erb
@@ -11,119 +11,83 @@ case $1 in
     chown -R vcap:vcap $RUN_DIR $LOG_DIR
 
     echo $$ > $PIDFILE
-	
-    #set server ips (or vip)
+
+    # set server ips (or vip)
     export servers="<% masters = link('k3s-server') %><% masters.instances.each do |instance| %> --server=https://<%= instance.address %>:6443 <% end %>"
 
-
-    #override server if vip
-<% if_p('k3s.master_vip_api') do |flag| %>
+<%- if_p('k3s.master_vip_api') do |flag| -%>
+    # override server if vip
     export servers=" --server=https://<%= flag %>:6443"
-<% end %>
-
-
+<%- end -%>
     export K3S_NODE_NAME=<%= spec.name %>-<%= spec.index %>
-
-
-<% if_p('k3s.node_name_prefix') do |prefix| %>
+<%- if_p('k3s.node_name_prefix') do |prefix| -%>
     export K3S_NODE_NAME=<%= prefix %>-<%= spec.index %>
-<% end %>
-
-
-
-
-
-
-    <% if_p('k3s.token-file-content') do |value| %>
+<%- end -%>
+<%- if_p('k3s.token-file-content') do |_| -%>
     export K3S_TOKEN_FILE=/var/vcap/jobs/k3s-agent/config/token.csv
-    <% end %>
+<%- end -%>
 
     export FLAGS=""
-    
-    #adapt kubelet root dir to match bosh fs
+
+    # adapt kubelet root dir to match bosh fs
     export FLAGS="$FLAGS --kubelet-arg=root-dir=/var/vcap/data/k3s-agent/kubelet"
 
-<% if_p('k3s.set-provider-id-prefix') do |prefix| %>
+<%- if_p('k3s.set-provider-id-prefix') do |prefix| -%>
     export FLAGS="$FLAGS --kubelet-arg=provider-id=<%= prefix %>://<%= spec.name %>-<%= spec.index %>"
-<% end %>
-
-
-<% if_p('k3s.vmodule') do |vmodule| %>
+<%- end -%>
+<%- if_p('k3s.vmodule') do |vmodule| -%>
     export FLAGS="$FLAGS --vmodule <%= vmodule %>"    
-<% end %>
-
-
-
-<% if_p('k3s.node-labels') do |value| %>
-<% p('k3s.node-labels').each do |label| %>
+<%- end -%>
+<%- p('k3s.node-labels',[]).each do |label| -%>
     export FLAGS="$FLAGS --node-label <%= label %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.node-taints') do |value| %>
-<% p('k3s.node-taints').each do |taint| %>
+<%- end -%>
+<%- p('k3s.node-taints',[]).each do |taint| -%>
     export FLAGS="$FLAGS --node-taint=<%= taint %>"
-<% end %>
-<% end %>
-
-
-<% if_p('k3s.kube-proxy-arg') do |value| %>
-<% p('k3s.kube-proxy-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-proxy-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-proxy-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kubelet-args') do |value| %>
-<% p('k3s.kubelet-args').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kubelet-args',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kubelet-arg=<%= flag %>"
-<% end %>
-<% end %>
+<%- end -%>
+<%- p('k3s.containerd_additional_env_vars',[]).each do |var| -%>
+    export CONTAINERD_<%= var['name'] %>="<%= var['value'] %>"
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.first.ip -%>
+    # set external ip flags
+    # define first ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.last.ip -%>
+    # define last ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
+<%- end -%>
+<%- if_p('k3s.kubelet-config-file') do |_| -%>
+    export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-agent/config/kubelet-config.yaml"
+<%- end -%>
 
-
-<% if_p('k3s.containerd_additional_env_vars') do |value| %>
-<% p('k3s.containerd_additional_env_vars').each do |var| %>
-  export CONTAINERD_<%= var['name'] %>="<%= var['value'] %>"
-<% end %>
-<% end %>
-
-
-#set external ip flags
-<% if spec.ip != spec.networks.marshal_dump.values.first.ip %>
-#define first ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
-<% end %>
-
-<% if spec.ip != spec.networks.marshal_dump.values.last.ip %>
-#define last ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
-<% end %>
-
-<% if_p('k3s.kubelet-config-file') do |value| %>
-export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-agent/config/kubelet-config.yaml"
-<% end %>
-
-export FLAGS="$FLAGS --prefer-bundled-bin"
+    export FLAGS="$FLAGS --prefer-bundled-bin"
 
     ulimit -n 1048576    # open files
     ulimit -u unlimited  # num processes
     mount --make-rshared /
 
     exec  /var/vcap/packages/k3s/k3s agent \
-    -v <%= p('k3s.v') %> \
-    --token=<%= p('k3s.token') %> \
-    --data-dir=/var/vcap/store/k3s-agent \
-    --private-registry=/var/vcap/jobs/k3s-agent/config/registries.yaml \
-    --resolv-conf=/etc/resolv.conf \
-    --node-ip=<%= spec.ip %> \
-    --node-label bosh.io/az=<%= spec.az %> \
-    --node-label bosh.io/name=<%= spec.name %> \
-    --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
-    --node-label bosh.io/index=<%= spec.index %>  \
-    --node-label bosh.io/address=<%= spec.ip %>  \
-    --node-label bosh.io/id=<%= spec.id %>  \
-    --node-label bosh.io/deployment=<%= spec.deployment %> \
-    --node-label bosh.io/agent=true \
-    --node-label topology.kubernetes.io/zone=<%= spec.az %> \
+      -v <%= p('k3s.v') %> \
+      --token=<%= p('k3s.token') %> \
+      --data-dir=/var/vcap/store/k3s-agent \
+      --private-registry=/var/vcap/jobs/k3s-agent/config/registries.yaml \
+      --resolv-conf=/etc/resolv.conf \
+      --node-ip=<%= spec.ip %> \
+      --node-label bosh.io/az=<%= spec.az %> \
+      --node-label bosh.io/name=<%= spec.name %> \
+      --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
+      --node-label bosh.io/index=<%= spec.index %>  \
+      --node-label bosh.io/address=<%= spec.ip %>  \
+      --node-label bosh.io/id=<%= spec.id %>  \
+      --node-label bosh.io/deployment=<%= spec.deployment %> \
+      --node-label bosh.io/agent=true \
+      --node-label topology.kubernetes.io/zone=<%= spec.az %> \
       $FLAGS \
       $servers \
       >>  $LOG_DIR/k3s-agent.stdout.log \
@@ -141,8 +105,3 @@ export FLAGS="$FLAGS --prefer-bundled-bin"
     echo "Usage: ctl {start|stop}" ;;
 
 esac
-
-
-
-
-

--- a/jobs/k3s-agent/templates/bin/pre-start.erb
+++ b/jobs/k3s-agent/templates/bin/pre-start.erb
@@ -1,11 +1,37 @@
 #!/bin/bash
 
-
 export JOB_DIR="/var/vcap/jobs/k3s-agent"
-/var/vcap/packages/k3s/k3s check-config
-
 # Setup ssh env vars
 ${JOB_DIR}/bin/setup-user-env
+
+source /var/vcap/packages/k3s-utils/functions.sh
+assert_declared_functions 'k3s_check_config' 'disable_ni_hardware_option' 'force_link_dir'
+
+# Adapt the kubelet root directory to match the BOSH filesystem structure.
+# Kubelet ignores the root-dir argument and creates the socket at:
+# /var/lib/kubelet/device-plugins/=kubelet.sock
+# Therefore, we linked /var/lib/kubelet to the specified root directory.
+# https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation
+
+force_link_dir "/var/vcap/data/k3s-agent/kubelet" "/var/lib/kubelet"
+
+if k3s_check_config; then
+  echo "k3s check-config success"
+else
+  echo "k3s check-config failure, check logs"
+  exit 1
+fi
+
+# Create secrets
+SECRETS_DIR='<%= p("k3s.host-secrets.dir") %>'
+mkdir -p "$SECRETS_DIR"
+<% p("k3s.host-secrets.files", []).each do |stc| %>
+# <%= stc["name"] %>
+/bin/cat > "$SECRETS_DIR/<%= stc['name'] %>" << END_OF_SECRET
+<%= stc["content"] %>
+END_OF_SECRET
+<% end %>
+chown -R vcap:vcap "$SECRETS_DIR"
 
 # Prepare a persistent directory so /etc/rancher/node paswword file is kept on bosh recreate
 mkdir -p /etc
@@ -36,26 +62,9 @@ INTERFACE="$(ip --brief address show | grep "${OVERLAY_IP}" | awk '{print $1}')"
 #clean previous patch services
 ! rm -f /etc/systemd/system/ethtool-patch-*.service
 
+#--- Disable hardware option on private interface
 <% p('k3s.disable-vxlan-hardware-options').each do |option| %>
- #--- Disable hardware option on private interface
-OPTION="<%= option %>"
-if [ "${OPTION}" != "" ] ; then
-serviceFile="ethtool-patch-${INTERFACE}-${OPTION}.service"
-cat > /etc/systemd/system/${serviceFile} << EOF
-[Unit]
-Description=Turn off ${OPTION} on ${INTERFACE}
-After=sys-subsystem-net-devices-${INTERFACE}.device
-[Install]
-WantedBy=sys-subsystem-net-devices-${INTERFACE}.device
-[Service]
-Type=oneshot
-ExecStart=/sbin/ethtool -K ${INTERFACE} ${OPTION} off
-EOF
-
-#--- Start service
-/usr/bin/systemctl enable ${serviceFile}
-/usr/bin/systemctl start ${serviceFile}
-fi
+disable_ni_hardware_option "<%= option %>"
 <% end %>
 
 exit 0

--- a/jobs/k3s-server/spec
+++ b/jobs/k3s-server/spec
@@ -1,7 +1,9 @@
 ---
 name: k3s-server
 
-packages: []
+packages:
+  - k3s-utils
+
 templates:
   config/bpm.yml: config/bpm.yml
   bin/pre-start.erb: bin/pre-start
@@ -77,6 +79,24 @@ properties:
 
   k3s.token:
     description: (cluster) Shared secret used to join a server or agent to a cluster [$K3S_TOKEN]
+
+  k3s.host-secrets.dir:
+    description: a directory of secrets to create
+    default: /var/vcap/data/secrets
+
+  k3s.host-secrets.files:
+    description: a list of secrets to create
+    default: []
+    example: |
+      - name: cloud.conf
+        content: |+
+          [Global]
+          auth-url=https://openstack.internal:5000/v3
+          domain-name=Default
+          region=RegionOne
+          tenant-id=badcafefeddeadbeeffacedeafbadcad
+          username=k3s-admin
+          password=**********
 
   k3s.kubelet-args:
     description: (agent/flags) Customized flag for kubelet process

--- a/jobs/k3s-server/templates/bin/ctl.erb
+++ b/jobs/k3s-server/templates/bin/ctl.erb
@@ -10,227 +10,136 @@ case $1 in
   start)
     mkdir -p $RUN_DIR $LOG_DIR
     chown -R vcap:vcap $RUN_DIR $LOG_DIR
-    
+
     export K3S_NODE_NAME=<%= spec.name %>-<%= spec.index %>
-    
-    
-<% if_p('k3s.node_name_prefix') do |prefix| %>
+<%- if_p('k3s.node_name_prefix') do |prefix| -%>
     export K3S_NODE_NAME=<%= prefix %>-<%= spec.index %>
-<% end %>
-
-    
-    <% if_p('k3s.datastore-endpoint') do |value| %>
+<%- end -%>
+<%- if_p('k3s.datastore-endpoint') do |_| -%>
     export K3S_DATASTORE_ENDPOINT=<%= p('k3s.datastore-endpoint') %>
-    <% end %>
-    
-    <% if_p('k3s.datastore-cafile') do |value| %>
+<%- end -%>
+<%- if_p('k3s.datastore-cafile') do |_| -%>
     export K3S_DATASTORE_CAFILE=/var/vcap/jobs/k3s-server/config/datastore-cafile
-    <% end %>
-
-    <% if_p('k3s.datastore-certfile') do |value| %>
+<%- end -%>
+<%- if_p('k3s.datastore-certfile') do |_| -%>
     export K3S_DATASTORE_CERTFILE=/var/vcap/jobs/k3s-server/config/datastore-certfile
-    <% end %>
-
-    <% if_p('k3s.datastore-keyfile') do |value| %>
+<%- end -%>
+<%- if_p('k3s.datastore-keyfile') do |_| -%>
     export K3S_DATASTORE_KEYFILE=/var/vcap/jobs/k3s-server/config/datastore-keyfile 
-    <% end %>
-    
-    <% if_p('k3s.token-file-content') do |value| %>
+<%- end -%>
+<%- if_p('k3s.token-file-content') do |_| -%>
     export K3S_TOKEN_FILE=/var/vcap/jobs/k3s-server/config/token.csv
-    <% end %>
-    
-    
+<%- end -%>
+
     export FLAGS=""
-    
-    #adapt kubelet root dir to match bosh fs
+    # adapt kubelet root dir to match bosh fs
     export FLAGS="$FLAGS --kubelet-arg=root-dir=/var/vcap/data/k3s-server/kubelet"
-    
-<% if_p('k3s.set-provider-id-prefix') do |prefix| %>
+<%- if_p('k3s.set-provider-id-prefix') do |prefix| -%>
     export FLAGS="$FLAGS --kubelet-arg=provider-id=<%= prefix %>://<%= spec.name %>-<%= spec.index %>"
-<% end %>
-    
-    
-<% if_p('k3s.disable') do |value| %>
-<% p('k3s.disable').each do |components| %>
+<%- end -%>
+<%- p('k3s.disable',[]).each do |components| -%>
     export FLAGS="$FLAGS --disable <%= components %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.disable-cloud-controller') do |value| %>
+<%- end -%>
+<%- if_p('k3s.disable-cloud-controller') do |_| -%>
     export FLAGS="$FLAGS --disable-cloud-controller"
-<% end %>
-
-<% if_p('k3s.etcd-expose-metrics') do |value| %>
+<%- end -%>
+<%- if_p('k3s.etcd-expose-metrics') do |_| -%>
     export FLAGS="$FLAGS --etcd-expose-metrics"
-<% end %>
-
-<% if_p('k3s.flannel-backend') do |value| %>
+<%- end -%>
+<%- if_p('k3s.flannel-backend') do |value| -%>
     export FLAGS="$FLAGS --flannel-backend=<%= value %>"
-<% end %>
-
-
-<% if_p('k3s.disable-network-policy') do |value| %>
+<%- end -%>
+<%- if_p('k3s.disable-network-policy') do |_| -%>
     export FLAGS="$FLAGS --disable-network-policy"
-<% end %>
-
-<% if_p('k3s.disable-kube-proxy') do |value| %>
+<%- end -%>
+<%- if_p('k3s.disable-kube-proxy') do |_| -%>
     export FLAGS="$FLAGS --disable-kube-proxy"
-<% end %>
-
-
-<% if_p('k3s.vmodule') do |vmodule| %>
+<%- end -%>
+<%- if_p('k3s.vmodule') do |vmodule| -%>
     export FLAGS="$FLAGS --vmodule <%= vmodule %>"    
-<% end %>
-
-
-<% if_p('k3s.node-labels') do |value| %>
-<% p('k3s.node-labels').each do |label| %>
+<%- end -%>
+<%- p('k3s.node-labels',[]).each do |label| -%>
     export FLAGS="$FLAGS --node-label <%= label %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.node-taints') do |value| %>
-<% p('k3s.node-taints').each do |taint| %>
+<%- end -%>
+<%- p('k3s.node-taints',[]).each do |taint| -%>
     export FLAGS="$FLAGS --node-taint=<%= taint %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-proxy-arg') do |value| %>
-<% p('k3s.kube-proxy-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-proxy-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-proxy-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-
-<% if_p('k3s.kube-apiserver-arg') do |value| %>
-<% p('k3s.kube-apiserver-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-apiserver-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-apiserver-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-scheduler-arg') do |value| %>
-<% p('k3s.kube-scheduler-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-scheduler-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-scheduler-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-controller-manager-arg') do |value| %>
-<% p('k3s.kube-controller-manager-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-controller-manager-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-controller-manager-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.additional_tls_sans') do |value| %>
-<% p('k3s.additional_tls_sans').each do |san| %>
+<%- end -%>
+<%- p('k3s.additional_tls_sans',[]).each do |san| -%>
     export FLAGS="$FLAGS --tls-san=<%= san %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-cloud-controller-manager-arg') do |value| %>
-<% p('k3s.kube-cloud-controller-manager-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-cloud-controller-manager-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-cloud-controller-manager-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-
-
-<% if_p('k3s.kubelet-args') do |value| %>
-<% p('k3s.kubelet-args').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kubelet-args',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kubelet-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-
-<% if_p('k3s.cluster-cidr') do |value| %>
+<%- end -%>
+<%- if_p('k3s.cluster-cidr') do |value| -%>
     export FLAGS="$FLAGS --cluster-cidr=<%= value %>"
-<% end %>
-
-<% if_p('k3s.service-cidr') do |value| %>
+<%- end -%>
+<%- if_p('k3s.service-cidr') do |value| -%>
     export FLAGS="$FLAGS --service-cidr=<%= value %>"
-<% end %>
-
-<% if_p('k3s.cluster-dns') do |value| %>
+<%- end -%>
+<%- if_p('k3s.cluster-dns') do |value| -%>
     export FLAGS="$FLAGS --cluster-dns=<%= value %>"
-<% end %>
-
-<% if_p('k3s.containerd_additional_env_vars') do |value| %>
-<% p('k3s.containerd_additional_env_vars').each do |var| %>
+<%- end -%>
+<%- p('k3s.containerd_additional_env_vars',[]).each do |var| -%>
     export CONTAINERD_<%= var['name'] %>="<%= var['value'] %>"
-<% end %>
-<% end %>
-
-#set tls san for api
-<% if_p('k3s.master_vip_api') do |flag| %>
+<%- end -%>
+<%- if_p('k3s.master_vip_api') do |flag| -%>
+    # set tls san for api
     export FLAGS="$FLAGS --tls-san=<%= flag %>"
-<% end %>
-
-
-<% if_p('k3s.embedded-registry') do |value| %>
-    export FLAGS="$FLAGS --embedded-registry"
-<% end %>
-
-
-
-#set external ip flags
-<% if spec.ip != spec.networks.marshal_dump.values.first.ip %>
-#define first ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
-<% end %>
-
-<% if spec.ip != spec.networks.marshal_dump.values.last.ip %>
-#define last ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
-<% end %>
-
-<% if_p('k3s.audit-policy-file') do |value| %>
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-path=/var/vcap/sys/log/k3s-server/audit.log"
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-policy-file=/var/vcap/jobs/k3s-server/config/audit-policy.yaml"
-
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxage=15"
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxbackup=5"
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxsize=10"
-
-
-<% end %>
-
-<% if_p('k3s.api-server-tracing-config-file') do |value| %>
-
-export FLAGS="$FLAGS --kube-apiserver-arg=tracing-config-file=/var/vcap/jobs/k3s-server/config/api-server-tracing-config.yaml"
-
-<% end %>
-
-
-
-
-export FLAGS="$FLAGS --prefer-bundled-bin"
-
-
-#get bootstrap server in cluster
-export BOOTSTRAP_SERVER=<%= link('k3s-server').instances[0].address %>
-
-
-<% if_p('k3s.etcd-args') do |value| %>
-<% p('k3s.etcd-args').each do |flag| %>
+<%- end -%>
+<%- if_p('k3s.embedded-registry') do |value| -%>
+    export FLAGS="$FLAGS --embedded-registry=<%= value %>""
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.first.ip %>
+    # set external ip flags
+    # define first ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.last.ip %>
+    # define last ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
+<%- end -%>
+<%- if_p('k3s.audit-policy-file') do |_| -%>
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-path=/var/vcap/sys/log/k3s-server/audit.log"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-policy-file=/var/vcap/jobs/k3s-server/config/audit-policy.yaml"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxage=15"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxbackup=5"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxsize=10"
+<%- end -%>
+<%- if_p('k3s.api-server-tracing-config-file') do |_| -%>
+    export FLAGS="$FLAGS --kube-apiserver-arg=tracing-config-file=/var/vcap/jobs/k3s-server/config/api-server-tracing-config.yaml"
+<%- end -%>
+    export FLAGS="$FLAGS --prefer-bundled-bin"
+<%- p('k3s.etcd-args',[]).each do |flag| -%>
     export FLAGS="$FLAGS --etcd-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.embedded-ha-etcd') do |value| %>
-
+<%- end -%>
+<%- if_p('k3s.embedded-ha-etcd') do |_| -%>
 <% if spec.bootstrap %>
-#bootstrap server: cluster-init
-export FLAGS="$FLAGS --cluster-init"
-<% else %>
-#non bootstrap server: server reference
-export FLAGS="$FLAGS --server=https://$BOOTSTRAP_SERVER:6443"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kubelet-config-file') do |value| %>
-export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-server/config/kubelet-config.yaml"
-<% end %>
-
-
+    # bootstrap server: cluster-init
+    export FLAGS="$FLAGS --cluster-init"
+<%- else %>
+    # non bootstrap server: get bootstrap server in cluster
+    export BOOTSTRAP_SERVER=<%= link('k3s-server').instances.select { |i| i.bootstrap }.first.address %>
+    export FLAGS="$FLAGS --server=https://$BOOTSTRAP_SERVER:6443"
+<%- end -%>
+<%- end -%>
+<%- if_p('k3s.kubelet-config-file') do |_| -%>
+    export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-server/config/kubelet-config.yaml"
+<%- end -%>
 
     echo $$ > $PIDFILE
 
@@ -238,28 +147,27 @@ export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-server/config/kubel
     ulimit -u unlimited  # num processes
     mount --make-rshared /
 
-
     exec  /var/vcap/packages/k3s/k3s server \
-    -v <%= p('k3s.v') %> \
-    --token=<%= p('k3s.token') %> \
-    --resolv-conf=/etc/resolv.conf \
-    --node-ip=<%= spec.ip %> \
-    --data-dir=/var/vcap/store/k3s-server \
-    --default-local-storage-path=/var/vcap/store/k3s-local-storage-path \
-    --private-registry=/var/vcap/jobs/k3s-server/config/registries.yaml \
-    --write-kubeconfig=/var/vcap/store/k3s-server/k3s.yaml \
-    --write-kubeconfig-mode=755 \
-    --tls-san=<%= spec.ip %> \
-    --tls-san=<%= spec.networks.send(spec.networks.methods(false).first).dns_record_name %> \
-    --node-label bosh.io/az=<%= spec.az %> \
-    --node-label bosh.io/name=<%= spec.name %> \
-    --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
-    --node-label bosh.io/index=<%= spec.index %>  \
-    --node-label bosh.io/address=<%= spec.ip %>  \
-    --node-label bosh.io/id=<%= spec.id %>  \
-    --node-label bosh.io/deployment=<%= spec.deployment %> \
-    --node-label bosh.io/server=true \
-    --node-label topology.kubernetes.io/zone=<%= spec.az %> \
+      -v <%= p('k3s.v') %> \
+      --token=<%= p('k3s.token') %> \
+      --resolv-conf=/etc/resolv.conf \
+      --node-ip=<%= spec.ip %> \
+      --data-dir=/var/vcap/store/k3s-server \
+      --default-local-storage-path=/var/vcap/store/k3s-local-storage-path \
+      --private-registry=/var/vcap/jobs/k3s-server/config/registries.yaml \
+      --write-kubeconfig=/var/vcap/store/k3s-server/k3s.yaml \
+      --write-kubeconfig-mode=755 \
+      --tls-san=<%= spec.ip %> \
+      --tls-san=<%= spec.networks.send(spec.networks.methods(false).first).dns_record_name %> \
+      --node-label bosh.io/az=<%= spec.az %> \
+      --node-label bosh.io/name=<%= spec.name %> \
+      --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
+      --node-label bosh.io/index=<%= spec.index %>  \
+      --node-label bosh.io/address=<%= spec.ip %>  \
+      --node-label bosh.io/id=<%= spec.id %>  \
+      --node-label bosh.io/deployment=<%= spec.deployment %> \
+      --node-label bosh.io/server=true \
+      --node-label topology.kubernetes.io/zone=<%= spec.az %> \
       $FLAGS \
       >>  $LOG_DIR/k3s-server.stdout.log \
       2>> $LOG_DIR/k3s-server.stderr.log
@@ -275,8 +183,3 @@ export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-server/config/kubel
     echo "Usage: ctl {start|stop}" ;;
 
 esac
-
-
-
-
-

--- a/jobs/k3s-server/templates/bin/pre-start.erb
+++ b/jobs/k3s-server/templates/bin/pre-start.erb
@@ -13,7 +13,7 @@ assert_declared_functions 'k3s_check_config' 'disable_ni_hardware_option' 'force
 # Therefore, we linked /var/lib/kubelet to the specified root directory.
 # https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation
 
-force_link_dir "/var/vcap/data/k3s-agent/kubelet" "/var/lib/kubelet"
+force_link_dir "/var/vcap/data/k3s-server/kubelet" "/var/lib/kubelet"
 
 if k3s_check_config; then
   echo "k3s check-config success"

--- a/jobs/k3s-server/templates/bin/pre-start.erb
+++ b/jobs/k3s-server/templates/bin/pre-start.erb
@@ -1,9 +1,37 @@
 #!/bin/bash
-export JOB_DIR="/var/vcap/jobs/k3s-server"
-/var/vcap/packages/k3s/k3s check-config
 
+export JOB_DIR="/var/vcap/jobs/k3s-server"
 # Setup ssh env vars
 ${JOB_DIR}/bin/setup-user-env
+
+source /var/vcap/packages/k3s-utils/functions.sh
+assert_declared_functions 'k3s_check_config' 'disable_ni_hardware_option' 'force_link_dir'
+
+# Adapt the kubelet root directory to match the BOSH filesystem structure.
+# Kubelet ignores the root-dir argument and creates the socket at:
+# /var/lib/kubelet/device-plugins/=kubelet.sock
+# Therefore, we linked /var/lib/kubelet to the specified root directory.
+# https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation
+
+force_link_dir "/var/vcap/data/k3s-agent/kubelet" "/var/lib/kubelet"
+
+if k3s_check_config; then
+  echo "k3s check-config success"
+else
+  echo "k3s check-config failure, check logs"
+  exit 1
+fi
+
+# Create secrets
+SECRETS_DIR='<%= p("k3s.host-secrets.dir") %>'
+mkdir -p "$SECRETS_DIR"
+<% p("k3s.host-secrets.files", []).each do |stc| %>
+# <%= stc["name"] %>
+/bin/cat > "$SECRETS_DIR/<%= stc['name'] %>" << END_OF_SECRET
+<%= stc["content"] %>
+END_OF_SECRET
+<% end %>
+chown -R vcap:vcap "$SECRETS_DIR"
 
 # Prepare a persistent directory so /etc/rancher/node paswword file is kept on bosh recreate
 mkdir -p /etc
@@ -41,26 +69,9 @@ INTERFACE="$(ip --brief address show | grep "${OVERLAY_IP}" | awk '{print $1}')"
 #clean previous patch services
 ! rm -f /etc/systemd/system/ethtool-patch-*.service
 
+#--- Disable hardware option on private interface
 <% p('k3s.disable-vxlan-hardware-options').each do |option| %>
- #--- Disable hardware option on private interface
-OPTION="<%= option %>"
-if [ "${OPTION}" != "" ] ; then
-serviceFile="ethtool-patch-${INTERFACE}-${OPTION}.service"
-cat > /etc/systemd/system/${serviceFile} << EOF
-[Unit]
-Description=Turn off ${OPTION} on ${INTERFACE}
-After=sys-subsystem-net-devices-${INTERFACE}.device
-[Install]
-WantedBy=sys-subsystem-net-devices-${INTERFACE}.device
-[Service]
-Type=oneshot
-ExecStart=/sbin/ethtool -K ${INTERFACE} ${OPTION} off
-EOF
-
-#--- Start service
-/usr/bin/systemctl enable ${serviceFile}
-/usr/bin/systemctl start ${serviceFile}
-fi
+disable_ni_hardware_option "<%= option %>"
 <% end %>
 
 exit 0

--- a/packages/k3s-utils/packaging
+++ b/packages/k3s-utils/packaging
@@ -1,0 +1,4 @@
+set -e
+
+cp -a "k3s-utils/"* "${BOSH_INSTALL_TARGET:?}/"
+chmod +x "${BOSH_INSTALL_TARGET:?}/"*

--- a/packages/k3s-utils/spec
+++ b/packages/k3s-utils/spec
@@ -1,0 +1,8 @@
+---
+name: k3s-utils
+
+dependencies: [ ]
+
+files:
+  - k3s-utils/*
+

--- a/src/k3s-utils/functions.sh
+++ b/src/k3s-utils/functions.sh
@@ -1,0 +1,75 @@
+assert_declared_functions() {
+  for func in "$@"; do
+    if ! declare -f "$func" > /dev/null; then
+      echo "Error: function $func is not declared!"
+      exit 1
+    fi
+  done
+}
+
+disable_ni_hardware_option() {
+  local OPTION=$1
+  if [ "${OPTION}" != "" ] ; then
+    serviceFile="ethtool-patch-${INTERFACE}-${OPTION}.service"
+    cat > "/etc/systemd/system/${serviceFile}" << EOF
+[Unit]
+Description=Turn off ${OPTION} on ${INTERFACE}
+After=network.target
+[Install]
+WantedBy=multi-user.target
+[Service]
+Type=oneshot
+ExecStart=/sbin/ethtool -K ${INTERFACE} ${OPTION} off
+EOF
+    #--- Start service
+    /usr/bin/systemctl enable "${serviceFile}"
+    /usr/bin/systemctl start "${serviceFile}"
+  fi
+}
+
+
+k3s_check_config() {
+  output=$(/var/vcap/packages/k3s/k3s check-config 2>&1)
+  exit_code=$?
+  # remove colors
+  output=$(echo -e "$output" | sed -r 's/\x1b\[[0-9;]*m//g')
+  echo -e "$output"
+  if [ $exit_code -eq 0 ] && echo "$output" | tail -n 1 | grep -q "STATUS: pass"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+normalize_path() {
+  echo "$1" | sed -E 's:/+:/:g' | sed -E 's:(.+)/$:\1:'
+}
+
+force_link_dir() {
+  local DIR_PATH
+  DIR_PATH=$(normalize_path "$1")
+  local LINK_PATH
+  LINK_PATH=$(normalize_path "$2")
+  if [ "$LINK_PATH" = "$DIR_PATH" ]; then
+    echo "The directory \"$DIR_PATH\" is the same as the link \"$LINK_PATH\""
+    return 1
+  else
+    mkdir -p "$DIR_PATH"
+    if [ -d "$LINK_PATH" ] && [ ! -L "$LINK_PATH" ]; then
+      # dist dir exists, remove it
+      rm -rf "$LINK_PATH"
+    fi
+    if [ ! -L "$LINK_PATH" ]; then
+      # link doesn't exist
+      ln -sf "$DIR_PATH" "$LINK_PATH"
+    else
+      # link exists
+      actual_target=$(readlink -f "$LINK_PATH")
+      if [ "$actual_target" != "$DIR_PATH" ]; then
+        rm -f "$LINK_PATH"
+        ln -sf "$DIR_PATH" "$LINK_PATH"
+      fi
+    fi
+  fi
+  return 0
+}


### PR DESCRIPTION
## Add Support for Hosting Secrets

This change allows you to store secrets in BOSH CredHub and place them in a hostPath to share with pods.

BOSH manifest example:
```
- type: replace
  path: /instance_groups/name=agent/jobs/name=k3s-agent/properties?/k3s?/host-secrets?/dir
  value: /var/vcap/data/secrets

- type: replace
  path: /instance_groups/name=agent/jobs/name=k3s-agent/properties?/k3s?/host-secrets?/files/-
  value:
    name: cloud.conf
    content: |+
      [Global]
      auth-url=((csi_cinder_auth_url))
      tls-insecure=((csi_cinder_tls_insecure))
      tenant-id=((csi_cinder_tenant_id))
      username=((csi_cinder_username))
      password=((csi_cinder_password))
      domain-name=((csi_cinder_domain))
      region=((csi_cinder_region))
      [BlockStorage]
      ignore-volume-az=((csi_cinder_ignore_volume_az))
```

K3s manifest example:
```
volumes:
- name: secret-cinderplugin
  hostPath:
    path: /var/vcap/data/secrets
    type: Directory
```

## Switch to Using `network.target` in Systemd

An error in my deployment indicated that the systemd unit `sys-subsystem-net-devices-eth0.device` does not exist. In systemd, network devices are not always available as `.device` units. Instead, you can use a more general dependency like `network.target`, which ensures that network services are available. This change allows the service to start once the network is properly configured, without relying on a specific device unit that may not be present.

## Kubelet root directory fix

Kubelet ignores the root-dir argument and creates the socket at:
/var/lib/kubelet/device-plugins/=kubelet.sock
Therefore, we linked /var/lib/kubelet to the specified root directory.
https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation

## Other Changes

I introduced the `k3s-utils` package to share functions between the server and agent jobs (DRY) and cleaned up the ERB code.