### PR TITLE
Make CSI plugins work, some improvements

### DIFF
--- a/jobs/k3s-agent/spec
+++ b/jobs/k3s-agent/spec
@@ -1,9 +1,10 @@
 ---
 name: k3s-agent
 
-packages: []
+packages:
+  - k3s-utils
+
 templates:
-  config/bpm.yml: config/bpm.yml
   bin/pre-start.erb: bin/pre-start
   bin/post-start.erb: bin/post-start  
   bin/pre-stop.erb: bin/pre-stop
@@ -46,6 +47,10 @@ properties:
 
   registry.mirrors.tls.ca:
     description: private registry ca
+
+  k3s.local_storage_dir:
+    description: ""
+    default: "/var/vcap/store/k3s-local-storage"
 
   k3s.node_name_prefix:
     description: explicitly set k8s node name. If not set, <instance-group-name>-<index> is set automatically. If set, name is <node_name_prefix>-<index> 
@@ -119,7 +124,8 @@ properties:
 
   k3s.bosh-post-start-delay-seconds:
     description: bosh post start tempo, to let the kubelet start the pods before bosh triggers another node update
-    default: 30
+    default: 0
+
   k3s.do-not-killall-on-post-stop:
     description: if set, the bosh post-stop script wont leverage k3s-killall.sh script
     default: false 
@@ -156,7 +162,7 @@ properties:
       #   # default value
       #   #endpoint: localhost:4317
       #   samplingRatePerMillion: 100
-        
+
 
   k3s.containerd_additional_env_vars:
     description: additional env vars to set for containerd (the key will be prefixed with CONTAINERD_, and set in k3s launch context

--- a/jobs/k3s-agent/templates/bin/ctl.erb
+++ b/jobs/k3s-agent/templates/bin/ctl.erb
@@ -1,133 +1,100 @@
-#!/bin/bash
+#!/bin/bash -eu
 
-RUN_DIR=/var/vcap/sys/run/k3s-agent
-LOG_DIR=/var/vcap/sys/log/k3s-agent
-PIDFILE=${RUN_DIR}/pid
+export RUN_DIR=/var/vcap/sys/run/k3s-agent
+export LOG_DIR=/var/vcap/sys/log/k3s-agent
+export JOB_DIR=/var/vcap/jobs/k3s-agent
+export DATA_DIR=/var/vcap/data/k3s-agent
+export STORE_DIR=/var/vcap/store/k3s-agent
+
+export LOCAL_STORAGE_DIR='<%= p('k3s.local_storage_dir') %>'
+
+export PIDFILE=${RUN_DIR}/pid
 
 case $1 in
 
   start)
-    mkdir -p $RUN_DIR $LOG_DIR
-    chown -R vcap:vcap $RUN_DIR $LOG_DIR
+    mkdir -p "$RUN_DIR" "$LOG_DIR"
+    chown -R vcap:vcap "$RUN_DIR" "$LOG_DIR"
 
     echo $$ > $PIDFILE
-	
-    #set server ips (or vip)
-    export servers="<% masters = link('k3s-server') %><% masters.instances.each do |instance| %> --server=https://<%= instance.address %>:6443 <% end %>"
 
+    # set server ips (or vip)
+    export SERVER_FLAGS='<%= link("k3s-server").instances.map{ |instance| "--server=https://#{instance.address}:6443" }.join(" ") %>'
 
-    #override server if vip
-<% if_p('k3s.master_vip_api') do |flag| %>
+<%- if_p('k3s.master_vip_api') do |flag| -%>
+    # override server if vip
     export servers=" --server=https://<%= flag %>:6443"
-<% end %>
-
-
+<%- end -%>
     export K3S_NODE_NAME=<%= spec.name %>-<%= spec.index %>
-
-
-<% if_p('k3s.node_name_prefix') do |prefix| %>
+<%- if_p('k3s.node_name_prefix') do |prefix| -%>
     export K3S_NODE_NAME=<%= prefix %>-<%= spec.index %>
-<% end %>
-
-
-
-
-
-
-    <% if_p('k3s.token-file-content') do |value| %>
-    export K3S_TOKEN_FILE=/var/vcap/jobs/k3s-agent/config/token.csv
-    <% end %>
+<%- end -%>
+<%- if_p('k3s.token-file-content') do |_| -%>
+    export K3S_TOKEN_FILE="$JOB_DIR/config/token.csv"
+<%- end -%>
 
     export FLAGS=""
-    
-    #adapt kubelet root dir to match bosh fs
-    export FLAGS="$FLAGS --kubelet-arg=root-dir=/var/vcap/data/k3s-agent/kubelet"
-
-<% if_p('k3s.set-provider-id-prefix') do |prefix| %>
+<%- if_p('k3s.set-provider-id-prefix') do |prefix| -%>
     export FLAGS="$FLAGS --kubelet-arg=provider-id=<%= prefix %>://<%= spec.name %>-<%= spec.index %>"
-<% end %>
-
-
-<% if_p('k3s.vmodule') do |vmodule| %>
+<%- end -%>
+<%- if_p('k3s.vmodule') do |vmodule| -%>
     export FLAGS="$FLAGS --vmodule <%= vmodule %>"    
-<% end %>
-
-
-
-<% if_p('k3s.node-labels') do |value| %>
-<% p('k3s.node-labels').each do |label| %>
+<%- end -%>
+<%- p('k3s.node-labels',[]).each do |label| -%>
     export FLAGS="$FLAGS --node-label <%= label %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.node-taints') do |value| %>
-<% p('k3s.node-taints').each do |taint| %>
+<%- end -%>
+<%- p('k3s.node-taints',[]).each do |taint| -%>
     export FLAGS="$FLAGS --node-taint=<%= taint %>"
-<% end %>
-<% end %>
-
-
-<% if_p('k3s.kube-proxy-arg') do |value| %>
-<% p('k3s.kube-proxy-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-proxy-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-proxy-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kubelet-args') do |value| %>
-<% p('k3s.kubelet-args').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kubelet-args',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kubelet-arg=<%= flag %>"
-<% end %>
-<% end %>
+<%- end -%>
+<%- p('k3s.containerd_additional_env_vars',[]).each do |var| -%>
+    export CONTAINERD_<%= var['name'] %>="<%= var['value'] %>"
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.first.ip -%>
+    # set external ip flags
+    # define first ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.last.ip -%>
+    # define last ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
+<%- end -%>
+<%- if_p('k3s.kubelet-config-file') do |_| -%>
+    export FLAGS="$FLAGS --kubelet-arg=config=$JOB_DIR/config/kubelet-config.yaml"
+<%- end -%>
 
-
-<% if_p('k3s.containerd_additional_env_vars') do |value| %>
-<% p('k3s.containerd_additional_env_vars').each do |var| %>
-  export CONTAINERD_<%= var['name'] %>="<%= var['value'] %>"
-<% end %>
-<% end %>
-
-
-#set external ip flags
-<% if spec.ip != spec.networks.marshal_dump.values.first.ip %>
-#define first ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
-<% end %>
-
-<% if spec.ip != spec.networks.marshal_dump.values.last.ip %>
-#define last ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
-<% end %>
-
-<% if_p('k3s.kubelet-config-file') do |value| %>
-export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-agent/config/kubelet-config.yaml"
-<% end %>
-
-export FLAGS="$FLAGS --prefer-bundled-bin"
+    export FLAGS="$FLAGS --prefer-bundled-bin"
 
     ulimit -n 1048576    # open files
     ulimit -u unlimited  # num processes
     mount --make-rshared /
 
     exec  /var/vcap/packages/k3s/k3s agent \
-    -v <%= p('k3s.v') %> \
-    --token=<%= p('k3s.token') %> \
-    --data-dir=/var/vcap/store/k3s-agent \
-    --private-registry=/var/vcap/jobs/k3s-agent/config/registries.yaml \
-    --resolv-conf=/etc/resolv.conf \
-    --node-ip=<%= spec.ip %> \
-    --node-label bosh.io/az=<%= spec.az %> \
-    --node-label bosh.io/name=<%= spec.name %> \
-    --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
-    --node-label bosh.io/index=<%= spec.index %>  \
-    --node-label bosh.io/address=<%= spec.ip %>  \
-    --node-label bosh.io/id=<%= spec.id %>  \
-    --node-label bosh.io/deployment=<%= spec.deployment %> \
-    --node-label bosh.io/agent=true \
-    --node-label topology.kubernetes.io/zone=<%= spec.az %> \
+      -v <%= p('k3s.v') %> \
+      --token=<%= p('k3s.token') %> \
+      --data-dir="/var/lib/kubelet" \
+      --private-registry="$JOB_DIR/config/registries.yaml" \
+      --resolv-conf=/etc/resolv.conf \
+      --node-ip=<%= spec.ip %> \
+      --node-label topology.kubernetes.io/zone=<%= spec.az %> \
+      --node-label bosh.io/az=<%= spec.az %> \
+      --node-label bosh.io/name=<%= spec.name %> \
+      --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
+      --node-label bosh.io/index=<%= spec.index %>  \
+      --node-label bosh.io/address=<%= spec.ip %>  \
+      --node-label bosh.io/id=<%= spec.id %>  \
+      --node-label bosh.io/deployment=<%= spec.deployment %> \
+      --node-label bosh.io/mode=agent \
+      --node-label bosh.io/agent=true \
       $FLAGS \
-      $servers \
-      >>  $LOG_DIR/k3s-agent.stdout.log \
-      2>> $LOG_DIR/k3s-agent.stderr.log
+      $SERVER_FLAGS \
+      >>  "$LOG_DIR/k3s-agent.stdout.log" \
+      2>> "$LOG_DIR/k3s-agent.stderr.log"
 
     ;;
 
@@ -141,8 +108,3 @@ export FLAGS="$FLAGS --prefer-bundled-bin"
     echo "Usage: ctl {start|stop}" ;;
 
 esac
-
-
-
-
-

--- a/jobs/k3s-agent/templates/bin/drain.erb
+++ b/jobs/k3s-agent/templates/bin/drain.erb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export JOB_DIR=/var/vcap/sys/log/k3s-agent
 
@@ -31,4 +31,4 @@ EOF
 
 <% end %>
 
-echo 0;
+echo 0

--- a/jobs/k3s-agent/templates/bin/post-deploy.erb
+++ b/jobs/k3s-agent/templates/bin/post-deploy.erb
@@ -1,1 +1,1 @@
-#!/bin/bash
+#!/bin/bash -eu

--- a/jobs/k3s-agent/templates/bin/post-start.erb
+++ b/jobs/k3s-agent/templates/bin/post-start.erb
@@ -1,34 +1,30 @@
-#!/bin/bash
+#!/bin/bash -eu
 
-if curl -I "http://127.0.0.1:10248/healthz" 2>&1 | grep -w "200\|301" ; then
-    echo "kubelet is up"
-else
-    echo "kubelet is down, post-start failure"
-fi
+source /var/vcap/packages/k3s-utils/functions.sh
+assert_declared_functions 'wait_for_http_service_ok' 'k3s_kubectl' 'k3s_wait_for_node_ready'
+
+wait_for_http_service_ok "http://127.0.0.1:10248/healthz" 300
 
 export K3S_NODE_NAME=<%= spec.name %>-<%= spec.index %>
-<% if_p('k3s.node_name_prefix') do |prefix| %>
-    export K3S_NODE_NAME=<%= prefix %>-<%= spec.index %>
-<% end %>
+<%- if_p('k3s.node_name_prefix') do |prefix| -%>
+export K3S_NODE_NAME=<%= prefix %>-<%= spec.index %>
+<%- end -%>
 
-
-#uncordon if agent drain set
-<% if_p('k3s.drain.kubeconfig') do |kubeconfig| %>
-#create local kubeconfig
-cat - > /var/vcap/data/k3s-agent/drain-kubeconfig.yaml <<EOF
+<%- if_p('k3s.drain.kubeconfig') do |kubeconfig| -%>
+# create local kubeconfig
+cat > /var/vcap/data/k3s-agent/drain-kubeconfig.yaml <<-EOF
 <%= kubeconfig %>
 EOF
 
+export KUBECONFIG="/var/vcap/data/k3s-agent/drain-kubeconfig.yaml"
 
-#uncordon
-/var/vcap/packages/k3s/k3s kubectl --kubeconfig=/var/vcap/data/k3s-agent/drain-kubeconfig.yaml uncordon $K3S_NODE_NAME \
->> $JOB_DIR/post-start.log \
-2>> $JOB_DIR/post-start-stderr.log
+k3s_wait_for_node_ready "$KUBECONFIG" "$K3S_NODE_NAME" 300
+echo "K3s node '$K3S_NODE_NAME' is ready"
 
-
-<% end %>
+# mark node as schedulable
+k3s_kubectl uncordon "$K3S_NODE_NAME" >> $JOB_DIR/post-start.log 2>> $JOB_DIR/post-start-stderr.log
+echo "K3s node '$K3S_NODE_NAME' is marked as schedulable"
+<%- end -%>
 
 #tempo to wait for kubelet to schedule pods before finishing instance group update
 sleep <%= p('k3s.bosh-post-start-delay-seconds') %>
-
-echo 0;

--- a/jobs/k3s-agent/templates/bin/post-stop.erb
+++ b/jobs/k3s-agent/templates/bin/post-stop.erb
@@ -1,6 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
 
- 
 <% if_p('k3s.do-not-killall-on-post-stop') do |value| %>
 <% if p('k3s.do-not-killall-on-post-stop') %>
 echo "post-stop: SKIP k3s-killall.sh"

--- a/jobs/k3s-agent/templates/bin/pre-start.erb
+++ b/jobs/k3s-agent/templates/bin/pre-start.erb
@@ -1,11 +1,32 @@
-#!/bin/bash
-
+#!/bin/bash -eu
 
 export JOB_DIR="/var/vcap/jobs/k3s-agent"
-/var/vcap/packages/k3s/k3s check-config
-
+export STORE_DIR="/var/vcap/store/k3s-agent"
 # Setup ssh env vars
 ${JOB_DIR}/bin/setup-user-env
+
+source /var/vcap/packages/k3s-utils/functions.sh
+assert_declared_functions 'k3s_check_config' 'disable_ni_hardware_option' 'mount_kubelet_to_bosh_data'
+
+# Adapt the kubelet root directory to match the BOSH filesystem structure.
+# Kubelet ignores the root-dir argument and creates the socket at:
+# /var/lib/kubelet/device-plugins/=kubelet.sock
+# Therefore, we linked /var/lib/kubelet to the specified root directory.
+# https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation
+
+export LOCAL_STORAGE_DIR='<%= p('k3s.local_storage_dir') %>'
+mkdir -p "$LOCAL_STORAGE_DIR"
+chown -R root:root "$LOCAL_STORAGE_DIR"
+chmod 775 "$LOCAL_STORAGE_DIR"
+
+mount_kubelet_to_bosh_data
+
+if k3s_check_config; then
+  echo "k3s check-config success"
+else
+  echo "k3s check-config failure, check logs"
+  exit 1
+fi
 
 # Prepare a persistent directory so /etc/rancher/node paswword file is kept on bosh recreate
 mkdir -p /etc
@@ -14,9 +35,9 @@ ln -sf /var/vcap/store/k3s-node/etc/rancher /etc/rancher
 
 #copy images to containerd expected location (datadir/images) for airgap start.
 # see https://rancher.com/docs/k3s/latest/en/installation/airgap/
-mkdir -p /var/vcap/store/k3s-agent/agent/images
-cp /var/vcap/packages/k3s-images/k3s-airgap-images-amd64.tar.gz /var/vcap/store/k3s-agent/agent/images
-gunzip -f /var/vcap/store/k3s-agent/agent/images/k3s-airgap-images-amd64.tar.gz
+mkdir -p "$STORE_DIR/agent/images"
+cp /var/vcap/packages/k3s-images/k3s-airgap-images-amd64.tar.gz "$STORE_DIR/agent/images"
+gunzip -f "$STORE_DIR/agent/images/k3s-airgap-images-amd64.tar.gz"
 
 
 set -e
@@ -37,25 +58,8 @@ INTERFACE="$(ip --brief address show | grep "${OVERLAY_IP}" | awk '{print $1}')"
 ! rm -f /etc/systemd/system/ethtool-patch-*.service
 
 <% p('k3s.disable-vxlan-hardware-options').each do |option| %>
- #--- Disable hardware option on private interface
-OPTION="<%= option %>"
-if [ "${OPTION}" != "" ] ; then
-serviceFile="ethtool-patch-${INTERFACE}-${OPTION}.service"
-cat > /etc/systemd/system/${serviceFile} << EOF
-[Unit]
-Description=Turn off ${OPTION} on ${INTERFACE}
-After=sys-subsystem-net-devices-${INTERFACE}.device
-[Install]
-WantedBy=sys-subsystem-net-devices-${INTERFACE}.device
-[Service]
-Type=oneshot
-ExecStart=/sbin/ethtool -K ${INTERFACE} ${OPTION} off
-EOF
-
-#--- Start service
-/usr/bin/systemctl enable ${serviceFile}
-/usr/bin/systemctl start ${serviceFile}
-fi
+#--- Disable hardware option on private interface
+disable_ni_hardware_option "<%= option %>"
 <% end %>
 
 exit 0

--- a/jobs/k3s-agent/templates/bin/pre-stop.erb
+++ b/jobs/k3s-agent/templates/bin/pre-stop.erb
@@ -1,2 +1,1 @@
-#!/bin/bash
-exit 0;
+#!/bin/bash -eu

--- a/jobs/k3s-server/spec
+++ b/jobs/k3s-server/spec
@@ -1,9 +1,10 @@
 ---
 name: k3s-server
 
-packages: []
+packages:
+  - k3s-utils
+
 templates:
-  config/bpm.yml: config/bpm.yml
   bin/pre-start.erb: bin/pre-start
   bin/post-start.erb: bin/post-start  
   bin/pre-stop.erb: bin/pre-stop
@@ -14,6 +15,8 @@ templates:
   bin/envrc: bin/envrc
   bin/setup-user-env.erb: bin/setup-user-env
   bin/k3s-killall.sh: bin/k3s-killall.sh
+
+  config/bosh-spec.yml.erb: config/bosh-spec.yml
 
   config/registries.yaml.erb: config/registries.yaml
   config/registry.ca.erb: config/registry.ca
@@ -53,6 +56,10 @@ properties:
 
   registry.mirrors.tls.ca:
     description: private registry ca
+
+  k3s.local_storage_dir:
+    description: ""
+    default: "/var/vcap/store/k3s-local-storage"
 
   k3s.v:
     description: "(logging) Number for the log level verbosity (default: 0)"
@@ -150,7 +157,7 @@ properties:
 
   k3s.bosh-post-start-delay-seconds:
     description: bosh post start tempo, to let the kubelet start the pods before bosh triggers another node update
-    default: 30
+    default: 0
 
   k3s.do-not-killall-on-post-stop:
     description: if set, the bosh post-stop script wont leverage k3s-killall.sh script

--- a/jobs/k3s-server/templates/bin/ctl.erb
+++ b/jobs/k3s-server/templates/bin/ctl.erb
@@ -1,236 +1,148 @@
-#!/bin/bash
+#!/bin/bash -eu
 
-JOB_DIR=/var/vcap/jobs/k3s-server
-RUN_DIR=/var/vcap/sys/run/k3s-server
-LOG_DIR=/var/vcap/sys/log/k3s-server
+export RUN_DIR=/var/vcap/sys/run/k3s-server
+export LOG_DIR=/var/vcap/sys/log/k3s-server
+export JOB_DIR=/var/vcap/jobs/k3s-server
+export DATA_DIR=/var/vcap/data/k3s-server
+export STORE_DIR=/var/vcap/store/k3s-server
+
+export LOCAL_STORAGE_DIR='<%= p('k3s.local_storage_dir') %>'
+
 PIDFILE=${RUN_DIR}/pid
 
 case $1 in
 
   start)
-    mkdir -p $RUN_DIR $LOG_DIR
-    chown -R vcap:vcap $RUN_DIR $LOG_DIR
-    
+    mkdir -p "$RUN_DIR" "$LOG_DIR"
+    chown -R vcap:vcap "$RUN_DIR" "$LOG_DIR"
+
     export K3S_NODE_NAME=<%= spec.name %>-<%= spec.index %>
-    
-    
-<% if_p('k3s.node_name_prefix') do |prefix| %>
+<%- if_p('k3s.node_name_prefix') do |prefix| -%>
     export K3S_NODE_NAME=<%= prefix %>-<%= spec.index %>
-<% end %>
-
-    
-    <% if_p('k3s.datastore-endpoint') do |value| %>
+<%- end -%>
+<%- if_p('k3s.datastore-endpoint') do |_| -%>
     export K3S_DATASTORE_ENDPOINT=<%= p('k3s.datastore-endpoint') %>
-    <% end %>
-    
-    <% if_p('k3s.datastore-cafile') do |value| %>
-    export K3S_DATASTORE_CAFILE=/var/vcap/jobs/k3s-server/config/datastore-cafile
-    <% end %>
+<%- end -%>
+<%- if_p('k3s.datastore-cafile') do |_| -%>
+    export K3S_DATASTORE_CAFILE="$JOB_DIR/config/datastore-cafile"
+<%- end -%>
+<%- if_p('k3s.datastore-certfile') do |_| -%>
+    export K3S_DATASTORE_CERTFILE="$JOB_DIR/config/datastore-certfile"
+<%- end -%>
+<%- if_p('k3s.datastore-keyfile') do |_| -%>
+    export K3S_DATASTORE_KEYFILE="$JOB_DIR/config/datastore-keyfile"
+<%- end -%>
+<%- if_p('k3s.token-file-content') do |_| -%>
+    export K3S_TOKEN_FILE="$JOB_DIR/config/token.csv"
+<%- end -%>
 
-    <% if_p('k3s.datastore-certfile') do |value| %>
-    export K3S_DATASTORE_CERTFILE=/var/vcap/jobs/k3s-server/config/datastore-certfile
-    <% end %>
-
-    <% if_p('k3s.datastore-keyfile') do |value| %>
-    export K3S_DATASTORE_KEYFILE=/var/vcap/jobs/k3s-server/config/datastore-keyfile 
-    <% end %>
-    
-    <% if_p('k3s.token-file-content') do |value| %>
-    export K3S_TOKEN_FILE=/var/vcap/jobs/k3s-server/config/token.csv
-    <% end %>
-    
-    
     export FLAGS=""
-    
-    #adapt kubelet root dir to match bosh fs
-    export FLAGS="$FLAGS --kubelet-arg=root-dir=/var/vcap/data/k3s-server/kubelet"
-    
-<% if_p('k3s.set-provider-id-prefix') do |prefix| %>
+<%- if_p('k3s.set-provider-id-prefix') do |prefix| -%>
     export FLAGS="$FLAGS --kubelet-arg=provider-id=<%= prefix %>://<%= spec.name %>-<%= spec.index %>"
-<% end %>
-    
-    
-<% if_p('k3s.disable') do |value| %>
-<% p('k3s.disable').each do |components| %>
+<%- end -%>
+<%- p('k3s.disable',[]).each do |components| -%>
     export FLAGS="$FLAGS --disable <%= components %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.disable-cloud-controller') do |value| %>
+<%- end -%>
+<%- if_p('k3s.disable-cloud-controller') do |_| -%>
     export FLAGS="$FLAGS --disable-cloud-controller"
-<% end %>
-
-<% if_p('k3s.etcd-expose-metrics') do |value| %>
+<%- end -%>
+<%- if_p('k3s.etcd-expose-metrics') do |_| -%>
     export FLAGS="$FLAGS --etcd-expose-metrics"
-<% end %>
-
-<% if_p('k3s.flannel-backend') do |value| %>
+<%- end -%>
+<%- if_p('k3s.flannel-backend') do |value| -%>
     export FLAGS="$FLAGS --flannel-backend=<%= value %>"
-<% end %>
-
-
-<% if_p('k3s.disable-network-policy') do |value| %>
+<%- end -%>
+<%- if_p('k3s.disable-network-policy') do |_| -%>
     export FLAGS="$FLAGS --disable-network-policy"
-<% end %>
-
-<% if_p('k3s.disable-kube-proxy') do |value| %>
+<%- end -%>
+<%- if_p('k3s.disable-kube-proxy') do |_| -%>
     export FLAGS="$FLAGS --disable-kube-proxy"
-<% end %>
-
-
-<% if_p('k3s.vmodule') do |vmodule| %>
+<%- end -%>
+<%- if_p('k3s.vmodule') do |vmodule| -%>
     export FLAGS="$FLAGS --vmodule <%= vmodule %>"    
-<% end %>
-
-
-<% if_p('k3s.node-labels') do |value| %>
-<% p('k3s.node-labels').each do |label| %>
+<%- end -%>
+<%- p('k3s.node-labels',[]).each do |label| -%>
     export FLAGS="$FLAGS --node-label <%= label %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.node-taints') do |value| %>
-<% p('k3s.node-taints').each do |taint| %>
+<%- end -%>
+<%- p('k3s.node-taints',[]).each do |taint| -%>
     export FLAGS="$FLAGS --node-taint=<%= taint %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-proxy-arg') do |value| %>
-<% p('k3s.kube-proxy-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-proxy-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-proxy-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-
-<% if_p('k3s.kube-apiserver-arg') do |value| %>
-<% p('k3s.kube-apiserver-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-apiserver-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-apiserver-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-scheduler-arg') do |value| %>
-<% p('k3s.kube-scheduler-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-scheduler-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-scheduler-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-controller-manager-arg') do |value| %>
-<% p('k3s.kube-controller-manager-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-controller-manager-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-controller-manager-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.additional_tls_sans') do |value| %>
-<% p('k3s.additional_tls_sans').each do |san| %>
+<%- end -%>
+<%- p('k3s.additional_tls_sans',[]).each do |san| -%>
     export FLAGS="$FLAGS --tls-san=<%= san %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kube-cloud-controller-manager-arg') do |value| %>
-<% p('k3s.kube-cloud-controller-manager-arg').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kube-cloud-controller-manager-arg',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kube-cloud-controller-manager-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-
-
-<% if_p('k3s.kubelet-args') do |value| %>
-<% p('k3s.kubelet-args').each do |flag| %>
+<%- end -%>
+<%- p('k3s.kubelet-args',[]).each do |flag| -%>
     export FLAGS="$FLAGS --kubelet-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-
-<% if_p('k3s.cluster-cidr') do |value| %>
+<%- end -%>
+<%- if_p('k3s.cluster-cidr') do |value| -%>
     export FLAGS="$FLAGS --cluster-cidr=<%= value %>"
-<% end %>
-
-<% if_p('k3s.service-cidr') do |value| %>
+<%- end -%>
+<%- if_p('k3s.service-cidr') do |value| -%>
     export FLAGS="$FLAGS --service-cidr=<%= value %>"
-<% end %>
-
-<% if_p('k3s.cluster-dns') do |value| %>
+<%- end -%>
+<%- if_p('k3s.cluster-dns') do |value| -%>
     export FLAGS="$FLAGS --cluster-dns=<%= value %>"
-<% end %>
-
-<% if_p('k3s.containerd_additional_env_vars') do |value| %>
-<% p('k3s.containerd_additional_env_vars').each do |var| %>
+<%- end -%>
+<%- p('k3s.containerd_additional_env_vars',[]).each do |var| -%>
     export CONTAINERD_<%= var['name'] %>="<%= var['value'] %>"
-<% end %>
-<% end %>
-
-#set tls san for api
-<% if_p('k3s.master_vip_api') do |flag| %>
+<%- end -%>
+<%- if_p('k3s.master_vip_api') do |flag| -%>
+    # set tls san for api
     export FLAGS="$FLAGS --tls-san=<%= flag %>"
-<% end %>
-
-
-<% if_p('k3s.embedded-registry') do |value| %>
-    export FLAGS="$FLAGS --embedded-registry"
-<% end %>
-
-
-
-#set external ip flags
-<% if spec.ip != spec.networks.marshal_dump.values.first.ip %>
-#define first ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
-<% end %>
-
-<% if spec.ip != spec.networks.marshal_dump.values.last.ip %>
-#define last ip as external_ip
-export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
-<% end %>
-
-<% if_p('k3s.audit-policy-file') do |value| %>
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-path=/var/vcap/sys/log/k3s-server/audit.log"
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-policy-file=/var/vcap/jobs/k3s-server/config/audit-policy.yaml"
-
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxage=15"
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxbackup=5"
-export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxsize=10"
-
-
-<% end %>
-
-<% if_p('k3s.api-server-tracing-config-file') do |value| %>
-
-export FLAGS="$FLAGS --kube-apiserver-arg=tracing-config-file=/var/vcap/jobs/k3s-server/config/api-server-tracing-config.yaml"
-
-<% end %>
-
-
-
-
-export FLAGS="$FLAGS --prefer-bundled-bin"
-
-
-#get bootstrap server in cluster
-export BOOTSTRAP_SERVER=<%= link('k3s-server').instances[0].address %>
-
-
-<% if_p('k3s.etcd-args') do |value| %>
-<% p('k3s.etcd-args').each do |flag| %>
+<%- end -%>
+<%- if_p('k3s.embedded-registry') do |value| -%>
+    export FLAGS="$FLAGS --embedded-registry=<%= value %>""
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.first.ip %>
+    # set external ip flags
+    # define first ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.first.ip %>"
+<%- end -%>
+<%- if spec.ip != spec.networks.marshal_dump.values.last.ip %>
+    # define last ip as external_ip
+    export FLAGS="$FLAGS --node-external-ip=<%= spec.networks.marshal_dump.values.last.ip %>"
+<%- end -%>
+<%- if_p('k3s.audit-policy-file') do |_| -%>
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-path=$LOG_DIR/audit.log"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-policy-file=$JOB_DIR/config/audit-policy.yaml"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxage=15"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxbackup=5"
+    export FLAGS="$FLAGS --kube-apiserver-arg=audit-log-maxsize=10"
+<%- end -%>
+<%- if_p('k3s.api-server-tracing-config-file') do |_| -%>
+    export FLAGS="$FLAGS --kube-apiserver-arg=tracing-config-file=$JOB_DIR/config/api-server-tracing-config.yaml"
+<%- end -%>
+    export FLAGS="$FLAGS --prefer-bundled-bin"
+<%- p('k3s.etcd-args',[]).each do |flag| -%>
     export FLAGS="$FLAGS --etcd-arg=<%= flag %>"
-<% end %>
-<% end %>
-
-<% if_p('k3s.embedded-ha-etcd') do |value| %>
-
+<%- end -%>
+<%- if_p('k3s.embedded-ha-etcd') do |_| -%>
 <% if spec.bootstrap %>
-#bootstrap server: cluster-init
-export FLAGS="$FLAGS --cluster-init"
-<% else %>
-#non bootstrap server: server reference
-export FLAGS="$FLAGS --server=https://$BOOTSTRAP_SERVER:6443"
-<% end %>
-<% end %>
-
-<% if_p('k3s.kubelet-config-file') do |value| %>
-export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-server/config/kubelet-config.yaml"
-<% end %>
-
-
+    # bootstrap server: cluster-init
+    export FLAGS="$FLAGS --cluster-init"
+<%- else %>
+    # non bootstrap server: get bootstrap server in cluster
+    export BOOTSTRAP_SERVER=<%= link('k3s-server').instances.select { |i| i.bootstrap }.first.address %>
+    export FLAGS="$FLAGS --server=https://$BOOTSTRAP_SERVER:6443"
+<%- end -%>
+<%- end -%>
+<%- if_p('k3s.kubelet-config-file') do |_| -%>
+    export FLAGS="$FLAGS --kubelet-arg=config=$JOB_DIR/config/kubelet-config.yaml"
+<%- end -%>
 
     echo $$ > $PIDFILE
 
@@ -238,31 +150,31 @@ export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-server/config/kubel
     ulimit -u unlimited  # num processes
     mount --make-rshared /
 
-
     exec  /var/vcap/packages/k3s/k3s server \
-    -v <%= p('k3s.v') %> \
-    --token=<%= p('k3s.token') %> \
-    --resolv-conf=/etc/resolv.conf \
-    --node-ip=<%= spec.ip %> \
-    --data-dir=/var/vcap/store/k3s-server \
-    --default-local-storage-path=/var/vcap/store/k3s-local-storage-path \
-    --private-registry=/var/vcap/jobs/k3s-server/config/registries.yaml \
-    --write-kubeconfig=/var/vcap/store/k3s-server/k3s.yaml \
-    --write-kubeconfig-mode=755 \
-    --tls-san=<%= spec.ip %> \
-    --tls-san=<%= spec.networks.send(spec.networks.methods(false).first).dns_record_name %> \
-    --node-label bosh.io/az=<%= spec.az %> \
-    --node-label bosh.io/name=<%= spec.name %> \
-    --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
-    --node-label bosh.io/index=<%= spec.index %>  \
-    --node-label bosh.io/address=<%= spec.ip %>  \
-    --node-label bosh.io/id=<%= spec.id %>  \
-    --node-label bosh.io/deployment=<%= spec.deployment %> \
-    --node-label bosh.io/server=true \
-    --node-label topology.kubernetes.io/zone=<%= spec.az %> \
+      -v <%= p('k3s.v') %> \
+      --token=<%= p('k3s.token') %> \
+      --data-dir="/var/lib/kubelet" \
+      --private-registry=$JOB_DIR/config/registries.yaml \
+      --resolv-conf=/etc/resolv.conf \
+      --node-ip=<%= spec.ip %> \
+      --node-label topology.kubernetes.io/zone=<%= spec.az %> \
+      --node-label bosh.io/az=<%= spec.az %> \
+      --node-label bosh.io/name=<%= spec.name %> \
+      --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
+      --node-label bosh.io/index=<%= spec.index %>  \
+      --node-label bosh.io/address=<%= spec.ip %>  \
+      --node-label bosh.io/id=<%= spec.id %>  \
+      --node-label bosh.io/deployment=<%= spec.deployment %> \
+      --node-label bosh.io/mode=server \
+      --node-label bosh.io/server=true \
+      --default-local-storage-path="$LOCAL_STORAGE_DIR" \
+      --write-kubeconfig="$STORE_DIR/k3s.yaml" \
+      --write-kubeconfig-mode=755 \
+      --tls-san='<%= spec.ip %>' \
+      --tls-san='<%= spec.networks.send(spec.networks.methods(false).first).dns_record_name %>' \
       $FLAGS \
-      >>  $LOG_DIR/k3s-server.stdout.log \
-      2>> $LOG_DIR/k3s-server.stderr.log
+      >>  "$LOG_DIR/k3s-server.stdout.log" \
+      2>> "$LOG_DIR/k3s-server.stderr.log"
     ;;
 
   stop)
@@ -275,8 +187,3 @@ export FLAGS="$FLAGS --kubelet-arg=config=/var/vcap/jobs/k3s-server/config/kubel
     echo "Usage: ctl {start|stop}" ;;
 
 esac
-
-
-
-
-

--- a/jobs/k3s-server/templates/bin/drain.erb
+++ b/jobs/k3s-server/templates/bin/drain.erb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export JOB_DIR=/var/vcap/sys/log/k3s-server
 
@@ -18,6 +18,6 @@ export K3S_NODE_NAME=<%= spec.name %>-<%= spec.index %>
 >> $JOB_DIR/drain.log \
 2>> $JOB_DIR/drain-stderr.log
 
-echo 0;
+echo 0
 
 

--- a/jobs/k3s-server/templates/bin/post-deploy.erb
+++ b/jobs/k3s-server/templates/bin/post-deploy.erb
@@ -1,1 +1,2 @@
-#!/bin/bash
+#!/bin/bash -eu
+

--- a/jobs/k3s-server/templates/bin/post-start.erb
+++ b/jobs/k3s-server/templates/bin/post-start.erb
@@ -1,25 +1,44 @@
-#!/bin/bash
+#!/bin/bash -eu
+
+source /var/vcap/packages/k3s-utils/functions.sh
+assert_declared_functions 'wait_for_file_creation' 'k3s_kubectl' 'k3s_wait_for_server_healthy' 'k3s_wait_for_node_ready' 'k3s_wait_for_system_pods_ready'
+
+export STORE_DIR="/var/vcap/store/k3s-server"
 
 export K3S_NODE_NAME=<%= spec.name %>-<%= spec.index %>
 <% if_p('k3s.node_name_prefix') do |prefix| %>
     export K3S_NODE_NAME=<%= prefix %>-<%= spec.index %>
 <% end %>
 
-#prepare kubeconfig for remote access 
-cat /var/vcap/store/k3s-server/k3s.yaml |sed -r 's/(\b[0-9]{1,3}\.){3}[0-9]{1,3}\b'/"<%= spec.ip %>"/ > /var/vcap/store/k3s-server/kubeconfig.yml
+wait_for_file_creation "$STORE_DIR/k3s.yaml" 180
+echo "File $STORE_DIR/k3s.yaml exists"
 
-<% if_p('k3s.master_vip_api') do |vip| %>
-cat /var/vcap/store/k3s-server/k3s.yaml |sed -r 's/(\b[0-9]{1,3}\.){3}[0-9]{1,3}\b'/"<%= vip %>"/ > /var/vcap/store/k3s-server/kubeconfig.yml
-<% end %>
+SERVER_IP='<%= spec.ip %>'
+<%- if_p('k3s.master_vip_api') do |vip| -%>
+SERVER_IP='<%= vip %>'
+<%- end -%>
 
-#wait for k8s api to be available, wait for 5 min max
-<% if_p('k3s.master_vip_api') do |vip| %>
-timeout 300 sh -c 'until nc -z <%= vip %> 6443; do sleep 1; done' /var/vcap/packages/k3s/k3s kubectl --kubeconfig=/var/vcap/store/k3s-server/kubeconfig.yml get pods --all-namespaces
-<% end %>
-#uncordon
-/var/vcap/packages/k3s/k3s kubectl --kubeconfig=/var/vcap/store/k3s-server/kubeconfig.yml uncordon $K3S_NODE_NAME
+# prepare kubeconfig for remote access
+cat "$STORE_DIR/k3s.yaml" | sed -r 's/(\b[0-9]{1,3}\.){3}[0-9]{1,3}\b'/"$SERVER_IP"/ > "$STORE_DIR/kubeconfig.yml"
 
+export KUBECONFIG="$STORE_DIR/kubeconfig.yml"
 
-#tempo to wait for kubelet to schedule pods before finishing instance group update
+# wait for k8s api to be available, wait for 5 minutes max
+timeout 300 sh -c "until nc -z $SERVER_IP 6443; do sleep 1; done"
+echo "Server is available"
 
-sleep <%= p('k3s.bosh-post-start-delay-seconds') %>
+k3s_wait_for_server_healthy "$KUBECONFIG" 300
+echo "K3s server is healthy"
+
+k3s_wait_for_node_ready "$KUBECONFIG" "$K3S_NODE_NAME" 300
+echo "K3s node '$K3S_NODE_NAME' is ready"
+
+# mark node as schedulable.
+k3s_kubectl uncordon "$K3S_NODE_NAME"
+echo "K3s node '$K3S_NODE_NAME' is marked as schedulable"
+
+k3s_wait_for_system_pods_ready "$KUBECONFIG" 300
+echo "K3s pods are ready"
+
+# tempo to wait for kubelet to schedule pods before finishing instance group update
+# sleep <%= p('k3s.bosh-post-start-delay-seconds') %>

--- a/jobs/k3s-server/templates/bin/post-stop.erb
+++ b/jobs/k3s-server/templates/bin/post-stop.erb
@@ -1,6 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eu
 
- 
 <% if_p('k3s.do-not-killall-on-post-stop') do |value| %>
 <% if p('k3s.do-not-killall-on-post-stop') %>
 echo "post-stop: SKIP k3s-killall.sh"

--- a/jobs/k3s-server/templates/bin/pre-start.erb
+++ b/jobs/k3s-server/templates/bin/pre-start.erb
@@ -1,9 +1,32 @@
-#!/bin/bash
-export JOB_DIR="/var/vcap/jobs/k3s-server"
-/var/vcap/packages/k3s/k3s check-config
+#!/bin/bash -eu
 
+export JOB_DIR="/var/vcap/jobs/k3s-server"
+export STORE_DIR="/var/vcap/store/k3s-server"
 # Setup ssh env vars
 ${JOB_DIR}/bin/setup-user-env
+
+source /var/vcap/packages/k3s-utils/functions.sh
+assert_declared_functions 'k3s_check_config' 'disable_ni_hardware_option' 'mount_kubelet_to_bosh_data'
+
+# Adapt the kubelet root directory to match the BOSH filesystem structure.
+# Kubelet ignores the root-dir argument and creates the socket at:
+# /var/lib/kubelet/device-plugins/=kubelet.sock
+# Therefore, we linked /var/lib/kubelet to the specified root directory.
+# https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation
+
+export LOCAL_STORAGE_DIR='<%= p('k3s.local_storage_dir') %>'
+mkdir -p "$LOCAL_STORAGE_DIR"
+chown -R root:root "$LOCAL_STORAGE_DIR"
+chmod 775 "$LOCAL_STORAGE_DIR"
+
+mount_kubelet_to_bosh_data
+
+if k3s_check_config; then
+  echo "k3s check-config success"
+else
+  echo "k3s check-config failure, check logs"
+  exit 1
+fi
 
 # Prepare a persistent directory so /etc/rancher/node paswword file is kept on bosh recreate
 mkdir -p /etc
@@ -11,18 +34,17 @@ mkdir -p /var/vcap/store/k3s-node/etc/rancher
 ln -sf /var/vcap/store/k3s-node/etc/rancher /etc/rancher
 
 # Fix cert chmod
-chmod go-r /var/vcap/jobs/k3s-server/config/datastore-*
+chmod go-r "$JOB_DIR/config/datastore-"*
 
 # Copy additional manifest file
-mkdir -p /var/vcap/store/k3s-server/
-cp -f ${JOB_DIR}/config/additional-manifest.yaml /var/vcap/store/k3s-server/server/manifests/additional-manifest.yaml
+mkdir -p "$STORE_DIR/server/manifests/"
+cp -f "$JOB_DIR/config/additional-manifest.yaml" "$STORE_DIR/server/manifests/additional-manifest.yaml"
 
 #copy images to containerd expected location (datadir/images) for airgap start.
 # see https://rancher.com/docs/k3s/latest/en/installation/airgap/
-mkdir -p /var/vcap/store/k3s-server/agent/images
-cp /var/vcap/packages/k3s-images/k3s-airgap-images-amd64.tar.gz /var/vcap/store/k3s-server/agent/images
-gunzip -f /var/vcap/store/k3s-server/agent/images/k3s-airgap-images-amd64.tar.gz
-
+mkdir -p "$STORE_DIR/agent/images"
+cp /var/vcap/packages/k3s-images/k3s-airgap-images-amd64.tar.gz "$STORE_DIR/agent/images"
+gunzip -f "$STORE_DIR/agent/images/k3s-airgap-images-amd64.tar.gz"
 
 set -e
 # Set overlay IP
@@ -42,25 +64,8 @@ INTERFACE="$(ip --brief address show | grep "${OVERLAY_IP}" | awk '{print $1}')"
 ! rm -f /etc/systemd/system/ethtool-patch-*.service
 
 <% p('k3s.disable-vxlan-hardware-options').each do |option| %>
- #--- Disable hardware option on private interface
-OPTION="<%= option %>"
-if [ "${OPTION}" != "" ] ; then
-serviceFile="ethtool-patch-${INTERFACE}-${OPTION}.service"
-cat > /etc/systemd/system/${serviceFile} << EOF
-[Unit]
-Description=Turn off ${OPTION} on ${INTERFACE}
-After=sys-subsystem-net-devices-${INTERFACE}.device
-[Install]
-WantedBy=sys-subsystem-net-devices-${INTERFACE}.device
-[Service]
-Type=oneshot
-ExecStart=/sbin/ethtool -K ${INTERFACE} ${OPTION} off
-EOF
-
-#--- Start service
-/usr/bin/systemctl enable ${serviceFile}
-/usr/bin/systemctl start ${serviceFile}
-fi
+#--- Disable hardware option on private interface
+disable_ni_hardware_option "<%= option %>"
 <% end %>
 
 exit 0

--- a/jobs/k3s-server/templates/bin/pre-stop.erb
+++ b/jobs/k3s-server/templates/bin/pre-stop.erb
@@ -1,2 +1,1 @@
-#!/bin/bash
-exit 0;
+#!/bin/bash -eu

--- a/packages/k3s-utils/packaging
+++ b/packages/k3s-utils/packaging
@@ -1,0 +1,4 @@
+set -e
+
+cp -a "k3s-utils/"* "${BOSH_INSTALL_TARGET:?}/"
+chmod +x "${BOSH_INSTALL_TARGET:?}/"*

--- a/packages/k3s-utils/spec
+++ b/packages/k3s-utils/spec
@@ -1,0 +1,8 @@
+---
+name: k3s-utils
+
+dependencies: [ ]
+
+files:
+  - k3s-utils/*
+

--- a/src/k3s-utils/functions.sh
+++ b/src/k3s-utils/functions.sh
@@ -1,0 +1,213 @@
+assert_declared_functions() {
+  for func in "$@"; do
+    if ! declare -f "$func" > /dev/null; then
+      echo "Error: function $func is not declared!"
+      exit 1
+    fi
+  done
+}
+
+disable_ni_hardware_option() {
+  local OPTION=$1
+  if [ "${OPTION}" != "" ] ; then
+    serviceFile="ethtool-patch-${INTERFACE}-${OPTION}.service"
+    cat > "/etc/systemd/system/${serviceFile}" << EOF
+[Unit]
+Description=Turn off ${OPTION} on ${INTERFACE}
+After=network.target
+[Install]
+WantedBy=multi-user.target
+[Service]
+Type=oneshot
+ExecStart=/sbin/ethtool -K ${INTERFACE} ${OPTION} off
+EOF
+    #--- Start service
+    /usr/bin/systemctl enable "${serviceFile}"
+    /usr/bin/systemctl start "${serviceFile}"
+  fi
+}
+
+
+k3s_check_config() {
+  output=$(/var/vcap/packages/k3s/k3s check-config 2>&1)
+  exit_code=$?
+  # remove colors
+  output=$(echo -e "$output" | sed -r 's/\x1b\[[0-9;]*m//g')
+  echo -e "$output"
+  if [ $exit_code -eq 0 ] && echo "$output" | tail -n 1 | grep -q "STATUS: pass"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+normalize_path() {
+  echo "$1" | sed -E 's:/+:/:g' | sed -E 's:(.+)/$:\1:'
+}
+
+force_link_dir() {
+  local DIR_PATH
+  DIR_PATH=$(normalize_path "$1")
+  local LINK_PATH
+  LINK_PATH=$(normalize_path "$2")
+  if [ "$LINK_PATH" = "$DIR_PATH" ]; then
+    echo "The directory \"$DIR_PATH\" is the same as the link \"$LINK_PATH\""
+    return 1
+  else
+    mkdir -p "$DIR_PATH"
+    if [ -d "$LINK_PATH" ] && [ ! -L "$LINK_PATH" ]; then
+      # dist dir exists, remove it
+      rm -rf "$LINK_PATH"
+    fi
+    if [ ! -L "$LINK_PATH" ]; then
+      # link doesn't exist
+      ln -sf "$DIR_PATH" "$LINK_PATH"
+    else
+      # link exists
+      actual_target=$(readlink -f "$LINK_PATH")
+      if [ "$actual_target" != "$DIR_PATH" ]; then
+        rm -f "$LINK_PATH"
+        ln -sf "$DIR_PATH" "$LINK_PATH"
+      fi
+    fi
+  fi
+  return 0
+}
+
+mount_kubelet_to_bosh_data() {
+  local kubelet_default="/var/lib/kubelet"
+  if [ ! -d "$kubelet_default" ]; then
+    mkdir -p "$kubelet_default"
+    chown -R root:root "$kubelet_default"
+    chmod 775 "$kubelet_default"
+  fi
+  local kubelet_bosh_data="/var/vcap/data/k3s-kubelet"
+  if [ ! -d "$kubelet_bosh_data" ]; then
+    mkdir -p "$kubelet_bosh_data"
+    chown -R root:root "$kubelet_bosh_data"
+    chmod 775 "$kubelet_bosh_data"
+  fi
+  if ! mountpoint -q "$kubelet_default"; then
+    mount --bind "$kubelet_bosh_data" "$kubelet_default"
+  fi
+}
+
+wait_for_file_creation() {
+  local file_path="$1"
+  local timeout="${2:-120}"
+  local start_time
+
+  start_time=$(date +%s)
+  while [[ ! -f "$file_path" ]]; do
+    local current_time
+    current_time=$(date +%s)
+    local elapsed_time=$((current_time - start_time))
+    if [[ $elapsed_time -ge $timeout ]]; then
+      local directory
+      directory=$(dirname "$file_path")
+      echo "Timeout reached: The file '$file_path' still doesn't exist after $timeout seconds."
+      echo "Files in the file directory $directory:"
+      ls -l "$directory"
+      return 1
+    fi
+    sleep 1
+  done
+  return 0
+}
+
+k3s_kubectl() {
+  /var/vcap/packages/k3s/k3s kubectl --insecure-skip-tls-verify "$@" && return 0
+  return 1
+}
+
+k3s_wait_for_server_healthy() {
+  local kubeconfig="$1"
+  local timeout="${2:-120}"
+  local start_time
+
+  start_time=$(date +%s)
+  while true; do
+    if k3s_kubectl --kubeconfig="$kubeconfig" get --raw='/healthz' > /dev/null 2>&1; then
+      return 0
+    fi
+    local current_time
+    current_time=$(date +%s)
+    local elapsed_time=$((current_time - start_time))
+    if [[ $elapsed_time -ge $timeout ]]; then
+      echo "Timeout reached: Server is still unhealthy after $timeout seconds, kubeconfig: '$kubeconfig'."
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+k3s_wait_for_node_ready() {
+  local kubeconfig="$1"
+  local node_name="$2"
+  local timeout="${3:-120}"
+  local start_time
+
+  start_time=$(date +%s)
+  while true; do
+    if k3s_kubectl --kubeconfig="$kubeconfig" get node "$node_name" &> /dev/null; then
+      sleep 10
+      k3s_kubectl --kubeconfig="$kubeconfig" wait --for=condition=Ready node "$node_name" --timeout="${timeout}s"
+      return 0
+    fi
+    local current_time
+    current_time=$(date +%s)
+    local elapsed_time=$((current_time - start_time))
+    if [[ $elapsed_time -ge $timeout ]]; then
+      echo "Timeout reached: Node '$node_name' is still NOT ready after $timeout seconds, kubeconfig: '$kubeconfig'."
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+k3s_wait_for_system_pods_ready() {
+  local kubeconfig="$1"
+  local timeout="${2:-120}"
+  local start_time
+
+  start_time=$(date +%s)
+  while true; do
+    local pod_count
+    pod_count=$(k3s_kubectl --kubeconfig="$kubeconfig" -n kube-system get pod -l '!batch.kubernetes.io/job-name' --no-headers 2>/dev/null | wc -l || echo 0)
+    if [ "$pod_count" -gt 0 ]; then
+      if k3s_kubectl --kubeconfig="$kubeconfig" wait --for=condition=Ready -n kube-system pod --all -l '!batch.kubernetes.io/job-name' --timeout="${timeout}s"; then
+        return 0
+      fi
+    fi
+    local current_time
+    current_time=$(date +%s)
+    local elapsed_time=$((current_time - start_time))
+    if [[ $elapsed_time -ge $timeout ]]; then
+      echo "Timeout reached: Pods are still NOT ready after $timeout seconds, kubeconfig: '$kubeconfig'."
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+
+wait_for_http_service_ok() {
+  local url="$1"
+  local timeout="${2:-120}"
+  local start_time
+
+  start_time=$(date +%s)
+  while true; do
+    if curl --insecure --silent --fail "$url" > /dev/null; then
+      exit 0
+    fi
+    local current_time
+    current_time=$(date +%s)
+    local elapsed_time=$((current_time - start_time))
+    if [[ $elapsed_time -ge $timeout ]]; then
+      echo "Timeout reached: HTTP service is still NOT ready after $timeout seconds, url: '$url'."
+      return 1
+    fi
+    sleep 1
+  done
+}


### PR DESCRIPTION
## Kubelet root directory fix

Kubelet ignores the root-dir argument and creates the socket at:
/var/lib/kubelet/device-plugins/=kubelet.sock
https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#device-plugin-implementation
Therefore, we mount /var/lib/kubelet to the BOSH data directory and keep it unchanged.

**This is the only way I've found to make the CSI plugins work.**

## Switch to Using `network.target` in Systemd

An error in my deployment indicated that the systemd unit `sys-subsystem-net-devices-eth0.device` does not exist. In systemd, network devices are not always available as `.device` units. Instead, you can use a more general dependency like `network.target`, which ensures that network services are available. This change allows the service to start once the network is properly configured, without relying on a specific device unit that may not be present.


## Other Changes

I introduced the `k3s-utils` package to share functions between the server and agent jobs (DRY) and cleaned up the ERB code.