### PR TITLE
Turn on db schema migration to prevent id exhaustion

### DIFF
--- a/jobs/k3s-server/templates/bin/ctl.erb
+++ b/jobs/k3s-server/templates/bin/ctl.erb
@@ -159,6 +159,9 @@ case $1 in
 <% end %>
 <% end %>
 
+# Turn on db schema migration to prevent id exhaustion, See issue https://github.com/orange-cloudfoundry/k3s-wrapper-boshrelease/issues/106
+export KINE_SCHEMA_MIGRATION=1
+
 #set tls san for api
 <% if_p('k3s.master_vip_api') do |flag| %>
     export FLAGS="$FLAGS --tls-san=<%= flag %>"


### PR DESCRIPTION
Fixes #106 by  hardcoing the environment variable declaration KINE_SCHEMA_MIGRATION=1